### PR TITLE
Add integration between Travis CI and Coveralls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,11 @@
                     </reportSet>
                 </reportSets>
             </plugin>
-
+			<plugin>
+    			<groupId>org.eluder.coveralls</groupId>
+   				<artifactId>coveralls-maven-plugin</artifactId>
+    			<version>4.0.0</version>
+			</plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>


### PR DESCRIPTION
Should get Coveralls working, which is located at https://coveralls.io/github/martijn9612/fishy. Coveralls provides us with information about how much of our code is coverd by test cases.
