### PR TITLE
moved testcases to packages <testing

### DIFF
--- a/src/test/java/nl/github/martijn9612/fishy/models/NonPlayerTest.java
+++ b/src/test/java/nl/github/martijn9612/fishy/models/NonPlayerTest.java
@@ -1,14 +1,15 @@
-package nl.github.martijn9612.fishy;
+package nl.github.martijn9612.fishy.models;
 
 import org.junit.Test;
 
 import junit.framework.TestCase;
+import nl.github.martijn9612.fishy.Main;
 import nl.github.martijn9612.fishy.models.NonPlayer;
 import nl.github.martijn9612.fishy.models.Vector;
 import nl.github.martijn9612.fishy.opponents.LinearOpponent;
 import nl.github.martijn9612.fishy.opponents.SinusOpponent;
 
-public class OpponentTest extends TestCase {
+public class NonPlayerTest extends TestCase {
 
 	/**
 	 * Test case for getSize method

--- a/src/test/java/nl/github/martijn9612/fishy/models/TestEntity.java
+++ b/src/test/java/nl/github/martijn9612/fishy/models/TestEntity.java
@@ -1,4 +1,4 @@
-package nl.github.martijn9612.fishy;
+package nl.github.martijn9612.fishy.models;
 
 import static org.mockito.Mockito.mock;
 

--- a/src/test/java/nl/github/martijn9612/fishy/opponents/LinearOpponentTest.java
+++ b/src/test/java/nl/github/martijn9612/fishy/opponents/LinearOpponentTest.java
@@ -1,4 +1,4 @@
-package nl.github.martijn9612.fishy;
+package nl.github.martijn9612.fishy.opponents;
 
 import static org.mockito.Mockito.mock;
 

--- a/src/test/java/nl/github/martijn9612/fishy/opponents/SinusOpponentTest.java
+++ b/src/test/java/nl/github/martijn9612/fishy/opponents/SinusOpponentTest.java
@@ -1,4 +1,4 @@
-package nl.github.martijn9612.fishy;
+package nl.github.martijn9612.fishy.opponents;
 
 import static org.mockito.Mockito.mock;
 

--- a/src/test/java/nl/github/martijn9612/fishy/position/PositionTest.java
+++ b/src/test/java/nl/github/martijn9612/fishy/position/PositionTest.java
@@ -1,8 +1,9 @@
-package nl.github.martijn9612.fishy;
+package nl.github.martijn9612.fishy.position;
 
 import org.junit.Test;
 
 import junit.framework.TestCase;
+import nl.github.martijn9612.fishy.Main;
 import nl.github.martijn9612.fishy.position.DrawPosition;
 import nl.github.martijn9612.fishy.position.MousePosition;
 import nl.github.martijn9612.fishy.position.MouseRectangle;

--- a/src/test/java/nl/github/martijn9612/fishy/powerups/PowerFactoryTest.java
+++ b/src/test/java/nl/github/martijn9612/fishy/powerups/PowerFactoryTest.java
@@ -1,4 +1,4 @@
-package nl.github.martijn9612.fishy;
+package nl.github.martijn9612.fishy.powerups;
 
 import static org.junit.Assert.*;
 import nl.github.martijn9612.fishy.powerups.Powerup;

--- a/src/test/java/nl/github/martijn9612/fishy/powerups/PowerupControllerTest.java
+++ b/src/test/java/nl/github/martijn9612/fishy/powerups/PowerupControllerTest.java
@@ -1,4 +1,4 @@
-package nl.github.martijn9612.fishy;
+package nl.github.martijn9612.fishy.powerups;
 
 import static org.junit.Assert.*;
 import nl.github.martijn9612.fishy.models.Player;

--- a/src/test/java/nl/github/martijn9612/fishy/powerups/PowerupTest.java
+++ b/src/test/java/nl/github/martijn9612/fishy/powerups/PowerupTest.java
@@ -1,4 +1,4 @@
-package nl.github.martijn9612.fishy;
+package nl.github.martijn9612.fishy.powerups;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;


### PR DESCRIPTION
It's easier to have all the testcases in sorted in packages because we can then easily see which classes are tested and which are not. 
