### PR TITLE
Fix Fish Facing The Wrong Direction <bug

### DIFF
--- a/src/main/java/nl/github/martijn9612/fishy/models/Entity.java
+++ b/src/main/java/nl/github/martijn9612/fishy/models/Entity.java
@@ -72,7 +72,6 @@ public abstract class Entity {
 		try {
 			originalImage = new Image(imagePath);
 			if (orientation != 0) {
-                System.out.println(orientation);
                 originalImage = originalImage.getFlippedCopy(true, false);
 			}
 		} catch (SlickException e) {

--- a/src/main/java/nl/github/martijn9612/fishy/models/Entity.java
+++ b/src/main/java/nl/github/martijn9612/fishy/models/Entity.java
@@ -71,6 +71,10 @@ public abstract class Entity {
 	public void loadImage(String imagePath) {
 		try {
 			originalImage = new Image(imagePath);
+			if (orientation != 0) {
+                System.out.println(orientation);
+                originalImage = originalImage.getFlippedCopy(true, false);
+			}
 		} catch (SlickException e) {
 			e.printStackTrace();
 		}


### PR DESCRIPTION
Player image was loaded in the game facing the wrong direction when the player is facing the other way than the image that is loaded in the game.
